### PR TITLE
Make end() work on errors in beforeMain

### DIFF
--- a/bin/bench-rest
+++ b/bin/bench-rest
@@ -138,7 +138,7 @@ benchrest(flow, runOptions)
     updateBar(percent, concurrent, ips);
   })
   .on('end', function (stats, errorCount) {
-    updateBar(100, 0, Math.round(stats.main.meter.mean));
+    updateBar(100, 0, (stats.main)? Math.round(stats.main.meter.mean) : 0);
     console.log('\n\nerrors: ', errorCount);
     console.log('stats: ', stats);
     process.exit(errorCount);


### PR DESCRIPTION
If an error happens in beforeMain, stats.main isn't initialized.
