### PR TITLE
Fix saveEtag hook

### DIFF
--- a/lib/bench-rest.js
+++ b/lib/bench-rest.js
@@ -217,7 +217,7 @@ var CORE_HOOKS = {
         res.headers.location :
         all.requestOptions.uri;
       if (!all.env.etags) all.env.etags = {};
-      all.env.etags[uri] = res.etag;
+      all.env.etags[uri] = res.headers.etag;
     }
     return all;
   },


### PR DESCRIPTION
The etag wouldn't be stored in the `all.env.etags` as the etag value was within the header not the response itself.