### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "commander": "^2.9.0",
     "measured": "^1.0.2",
     "progress2": "~0.1.1",
-    "request": "~2.65.0"
+    "request": "~2.74.0"
   },
   "devDependencies": {
     "accum": "^0.3.6",


### PR DESCRIPTION
bench-rest currently has a vulnerable dependency, introducing 2 different types of known vulnerabilities.

[ReDOS vulnerability](https://snyk.io/vuln/npm:tough-cookie:20160722) in the `tough-cookie` dependency and  [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.
You can see [Snyk test report](https://snyk.io/test/github/jeffbski/bench-rest) of this project for details.

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, which uses the fixed `tough-cookie` version 2.3.1, and does not pull in any other vulnerable dependencies.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).


Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)