### PR TITLE
let 'main' be a function that passes in Index

### DIFF
--- a/lib/bench-rest.js
+++ b/lib/bench-rest.js
@@ -110,11 +110,11 @@ function benchmark(flow, runOptions) {
   };
 
   function pushOnQueue() {
-    var tokens = { INDEX: index };
+    var tokens = {INDEX: index}
     queue.push({
       env: { index: index, jar: request.jar(), user: runOptions.user, password: runOptions.password, etags: {}, iterCtx: {}, stats: stats },
       beforeMain: bindSubtituteFnsWithTokens(flow.beforeMain, tokens),
-      main: bindSubtituteFnsWithTokens(flow.main, tokens),
+      main: typeof flow === 'function' ? flow(index).main : flow.main,
       afterMain: bindSubtituteFnsWithTokens(flow.afterMain, tokens)
     });
     index += 1;
@@ -161,10 +161,6 @@ function ensureFlowProperties(flow) {
     // assuming if none of these properties exist but does have properties
     //that this is a single operation as the main
     flow = { main: [flow] };
-  }
-
-  if (!Array.isArray(flow.main)) {
-    throw new Error('benchmark flow requires main operations, missing flow.main?');
   }
 
   if (!flow.before) flow.before = [];


### PR DESCRIPTION
Hello,

I was looking for a module just like this one, so was glad to find it :)

In my use case, I wanted each request to have different random information in the payload, or a random header. I assumed I could pass bench-rest a function, and it would call the function each time a request is generated so that I can easily calculate different parameters each time.


Here's an example of sending different coordinates to an api endpoint that tracks the location of a package:
```
  let flow = (index) => {
    return {
      main: [
        {
          post: `${env}/track`,
          headers: {
            'Auth-Token': _.sample(authTokens)
          },
          json: randomLocation(),
          delayAfter: 500,
        }
      ]
    }
  }
```

Notice how interpolation of the INDEX is no longer necessary, if we just have the flow defined as a function instead of a plain json object. The index can be passed in as the first argument and used by users if they choose.

Of course, the change is backwards compatible, if you pass in a plain object, it uses it. If you pass in a function it runs the function to get the object.

My implementation in this PR is a first draft. If you like the idea I can flesh-out the support and add docs.

What do you think?